### PR TITLE
Fixed a typo in the WW-BMG README.md

### DIFF
--- a/STL/WW-BMG for A4T/README.md
+++ b/STL/WW-BMG for A4T/README.md
@@ -6,14 +6,14 @@ This version has been made compatible with A4T by removing a small notch from th
 - Multiple filament path improvements
 - Options added for:
   - Smooth bearing idler, and
-  - Dual fialment sensors
+  - Dual filament sensors
 
 --------------------
 
 ## Multiple options for WW-BMG for A4T
 Choose your own adventure
 ### * Standard Extruder
-### * Dual fialment sensor
+### * Dual filament sensor
 ### * Smooth bearing idler or BMG 2nd drive gear tension arms
 
 --------------------


### PR DESCRIPTION
The README for the WW-BMG incorrectly states you need 4 M2x10 Self-Tapping screws for the smooth idler version, and none for the dual-sensor body.